### PR TITLE
Change to support helm 3 with out accesskeyid and secretkey

### DIFF
--- a/packaging/helm/aws-servicebroker/templates/broker-credentials.yaml
+++ b/packaging/helm/aws-servicebroker/templates/broker-credentials.yaml
@@ -10,6 +10,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  accesskeyid: {{ b64enc .Values.aws.accesskeyid }}
-  secretkey: {{ b64enc .Values.aws.secretkey }}
+  accesskeyid: "{{ b64enc .Values.aws.accesskeyid }}"
+  secretkey: "{{ b64enc .Values.aws.secretkey }}"
 {{- end }}


### PR DESCRIPTION
When using target role for authentication helm 3 raises a validation error on generated secrets since accesskeyid and secretkey are blank. Adding the quotes make sure the generated files pass validation

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/awslabs/aws-servicebroker/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add "[WIP]" to the beginning of the PR title
-->

## Overview

Brief description of what this PR does, and why it is needed (use case)?

## Related Issues

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

## Testing

How did you validate the changes in this PR? If there are unit tests included describe what they test

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
